### PR TITLE
Modernization pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.3.0
+=============
+
+    * Updated to 2018 edition of Rust
+    * Updated dependencies 
+
 Version 0.2.1
 =============
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapped-vec"
-version = "0.2.1"
+version = "0.3"
 authors = ["David Futcher <david@futcher.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wrapped-vec"
 version = "0.2.1"
 authors = ["David Futcher <david@futcher.io>"]
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Macro for generating wrapped Vec types and associated boilerplate"
 repository = "https://github.com/bobbo/wrapped-vec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrapped-vec"
-version = "0.3"
+version = "0.3.0"
 authors = ["David Futcher <david@futcher.io>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ categories = ["rust-patterns", "development-tools", "data-structures"]
 proc-macro = true
 
 [dependencies]
-syn = "0.11"
-quote = "0.3"
+proc-macro2 = "^1"
+quote = "^1"
+syn ="^1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,73 +47,73 @@ impl Idents {
     }
 }
 
-// struct Docs {
-//     wrapper: String,
-//     new: String,
-//     is_empty: String,
-//     len: String,
-//     iter: String,
-// }
+struct Docs {
+    wrapper: String,
+    new: String,
+    is_empty: String,
+    len: String,
+    iter: String,
+}
 
-// macro_rules! doc_attr {
-//     ($ast:ident, $attr:expr, $default:expr) => {
-//         attr_string_val($ast, $attr).unwrap_or($default);
-//     };
-// }
+macro_rules! doc_attr {
+    ($ast:ident, $attr:expr, $default:expr) => {
+        attr_string_val($ast, $attr).unwrap_or($default);
+    };
+}
 
-// impl Docs {
-//     fn new(ast: &DeriveInput, idents: &Idents) -> Docs {
-//         let wrapper = doc_attr!(
-//             ast,
-//             "CollectionDoc",
-//             format!("A collection of {}s", idents.item)
-//         );
-//         let new = doc_attr!(
-//             ast,
-//             "CollectionNewDoc",
-//             format!("Creates a new, empty {}", idents.collection)
-//         );
-//         let is_empty = doc_attr!(
-//             ast,
-//             "CollectionIsEmptyDoc",
-//             format!(
-//                 "Returns true if the {} contains no {}s",
-//                 idents.collection, idents.item
-//             )
-//         );
-//         let len = doc_attr!(
-//             ast,
-//             "CollectionLenDoc",
-//             format!(
-//                 "Returns the number of {}s in the {}",
-//                 idents.item, idents.collection
-//             )
-//         );
-//         let iter = doc_attr!(
-//             ast,
-//             "CollectionIterDoc",
-//             format!("Returns an iterator over the {}", idents.collection)
-//         );
+impl Docs {
+    fn new(ast: &DeriveInput, idents: &Idents) -> Docs {
+        let wrapper = doc_attr!(
+            ast,
+            "CollectionDoc",
+            format!("A collection of {}s", idents.item)
+        );
+        let new = doc_attr!(
+            ast,
+            "CollectionNewDoc",
+            format!("Creates a new, empty {}", idents.collection)
+        );
+        let is_empty = doc_attr!(
+            ast,
+            "CollectionIsEmptyDoc",
+            format!(
+                "Returns true if the {} contains no {}s",
+                idents.collection, idents.item
+            )
+        );
+        let len = doc_attr!(
+            ast,
+            "CollectionLenDoc",
+            format!(
+                "Returns the number of {}s in the {}",
+                idents.item, idents.collection
+            )
+        );
+        let iter = doc_attr!(
+            ast,
+            "CollectionIterDoc",
+            format!("Returns an iterator over the {}", idents.collection)
+        );
 
-//         Docs {
-//             wrapper: wrapper,
-//             new: new,
-//             is_empty: is_empty,
-//             len: len,
-//             iter: iter,
-//         }
-//     }
+        Docs {
+            wrapper: wrapper,
+            new: new,
+            is_empty: is_empty,
+            len: len,
+            iter: iter,
+        }
+    }
 
-//     fn as_parts(&self) -> (&String, &String, &String, &String, &String) {
-//         (
-//             &self.wrapper,
-//             &self.new,
-//             &self.is_empty,
-//             &self.len,
-//             &self.iter,
-//         )
-//     }
-// }
+    fn as_parts(&self) -> (&String, &String, &String, &String, &String) {
+        (
+            &self.wrapper,
+            &self.new,
+            &self.is_empty,
+            &self.len,
+            &self.iter,
+        )
+    }
+}
 
 #[proc_macro_derive(
     WrappedVec,
@@ -135,13 +135,13 @@ pub fn wrapped_vec(token_stream: proc_macro::TokenStream) -> proc_macro::TokenSt
 
 fn impl_wrapped_vec(input: &DeriveInput) -> Result<TokenStream, String> {
     let idents = Idents::new(input)?;
-    //     let docs = Docs::new(input, &idents);
-    Ok(generate_wrapped_vec(&idents /*, &docs*/))
+    let docs = Docs::new(input, &idents);
+    Ok(generate_wrapped_vec(&idents, &docs))
 }
 
-fn generate_wrapped_vec(idents: &Idents /*, docs: &Docs*/) -> TokenStream {
+fn generate_wrapped_vec(idents: &Idents, docs: &Docs) -> TokenStream {
     let (item_ident, collection_ident, collection_derive) = idents.as_parts();
-    // let (collection_doc, new_doc, is_empty_doc, len_doc, iter_doc) = docs.as_parts();
+    let (collection_doc, new_doc, is_empty_doc, len_doc, iter_doc) = docs.as_parts();
 
     let derives_toks = match collection_derive.clone() {
         Some(derives) => {
@@ -153,7 +153,7 @@ fn generate_wrapped_vec(idents: &Idents /*, docs: &Docs*/) -> TokenStream {
     };
 
     quote! {
-        // #[doc=#collection_doc]
+        #[doc=#collection_doc]
         #derives_toks
         pub struct #collection_ident(Vec<#item_ident>);
 
@@ -199,22 +199,22 @@ fn generate_wrapped_vec(idents: &Idents /*, docs: &Docs*/) -> TokenStream {
 
         impl #collection_ident {
 
-            // #[doc=#new_doc]
+            #[doc=#new_doc]
             pub fn new() -> #collection_ident {
                 #collection_ident(vec![])
             }
 
-            // #[doc=#is_empty_doc]
+            #[doc=#is_empty_doc]
             pub fn is_empty(&self) -> bool {
                 self.0.is_empty()
             }
 
-            // #[doc=#len_doc]
+            #[doc=#len_doc]
             pub fn len(&self) -> usize {
                 self.0.len()
             }
 
-            // #[doc=#iter_doc]
+            #[doc=#iter_doc]
             pub fn iter<'a>(&'a self) -> ::std::slice::Iter<'a, #item_ident> {
                 self.into_iter()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
 extern crate proc_macro;
 extern crate syn;
@@ -6,24 +6,24 @@ extern crate syn;
 extern crate quote;
 
 use proc_macro::TokenStream;
-use syn::{Ident, DeriveInput};
+use syn::{DeriveInput, Ident};
 
 struct Idents {
     item: Ident,
     collection: Ident,
-    derives: Option<Vec<Ident>>
+    derives: Option<Vec<Ident>>,
 }
 
 impl Idents {
-
     fn new(ast: &DeriveInput) -> Result<Idents, String> {
-        let collection_name = attr_string_val(ast, "CollectionName").expect("Need [CollectionName=\"...\"]");
+        let collection_name =
+            attr_string_val(ast, "CollectionName").expect("Need [CollectionName=\"...\"]");
         let derives = Idents::parse_derives(ast);
 
-        Ok(Idents{
+        Ok(Idents {
             item: ast.ident.clone(),
             collection: Ident::from(collection_name),
-            derives: derives
+            derives: derives,
         })
     }
 
@@ -31,19 +31,18 @@ impl Idents {
         match attr_string_val(ast, "CollectionDerives") {
             Some(derives_str) => {
                 if derives_str.is_empty() {
-                    return None
+                    return None;
                 }
 
                 Some(derives_str.split(",").map(Ident::from).collect())
-            },
-            None => None
+            }
+            None => None,
         }
     }
 
     fn as_parts(&self) -> (&Ident, &Ident, &Option<Vec<Ident>>) {
         (&self.item, &self.collection, &self.derives)
     }
-
 }
 
 struct Docs {
@@ -51,40 +50,71 @@ struct Docs {
     new: String,
     is_empty: String,
     len: String,
-    iter: String
+    iter: String,
 }
 
 macro_rules! doc_attr {
-    ($ast:ident, $attr:expr, $default:expr) => (
+    ($ast:ident, $attr:expr, $default:expr) => {
         attr_string_val($ast, $attr).unwrap_or($default);
-    )
+    };
 }
 
 impl Docs {
-
     fn new(ast: &DeriveInput, idents: &Idents) -> Docs {
-        let wrapper = doc_attr!(ast, "CollectionDoc", format!("A collection of {}s", idents.item));
-        let new = doc_attr!(ast, "CollectionNewDoc", format!("Creates a new, empty {}", idents.collection));
-        let is_empty = doc_attr!(ast, "CollectionIsEmptyDoc", format!("Returns true if the {} contains no {}s", idents.collection, idents.item));
-        let len = doc_attr!(ast, "CollectionLenDoc", format!("Returns the number of {}s in the {}", idents.item, idents.collection));
-        let iter = doc_attr!(ast, "CollectionIterDoc", format!("Returns an iterator over the {}", idents.collection));
+        let wrapper = doc_attr!(
+            ast,
+            "CollectionDoc",
+            format!("A collection of {}s", idents.item)
+        );
+        let new = doc_attr!(
+            ast,
+            "CollectionNewDoc",
+            format!("Creates a new, empty {}", idents.collection)
+        );
+        let is_empty = doc_attr!(
+            ast,
+            "CollectionIsEmptyDoc",
+            format!(
+                "Returns true if the {} contains no {}s",
+                idents.collection, idents.item
+            )
+        );
+        let len = doc_attr!(
+            ast,
+            "CollectionLenDoc",
+            format!(
+                "Returns the number of {}s in the {}",
+                idents.item, idents.collection
+            )
+        );
+        let iter = doc_attr!(
+            ast,
+            "CollectionIterDoc",
+            format!("Returns an iterator over the {}", idents.collection)
+        );
 
         Docs {
             wrapper: wrapper,
             new: new,
             is_empty: is_empty,
             len: len,
-            iter: iter
+            iter: iter,
         }
     }
 
     fn as_parts(&self) -> (&String, &String, &String, &String, &String) {
-        (&self.wrapper, &self.new, &self.is_empty, &self.len, &self.iter)
+        (
+            &self.wrapper,
+            &self.new,
+            &self.is_empty,
+            &self.len,
+            &self.iter,
+        )
     }
-
 }
 
-#[proc_macro_derive(WrappedVec, 
+#[proc_macro_derive(
+    WrappedVec,
     attributes(
         CollectionName,
         CollectionDerives,
@@ -100,9 +130,7 @@ pub fn wrapped_vec(input: TokenStream) -> TokenStream {
     let ast = syn::parse_derive_input(&s).unwrap();
 
     match impl_wrapped_vec(&ast) {
-        Ok(gen) => {
-            gen.parse().unwrap()
-        },
+        Ok(gen) => gen.parse().unwrap(),
         Err(err) => {
             panic!(err);
         }
@@ -122,10 +150,10 @@ fn generate_wrapped_vec(idents: &Idents, docs: &Docs) -> quote::Tokens {
 
     let derives_toks = match collection_derive.clone() {
         Some(derives) => {
-            quote!{ #[derive(#(#derives),*)] }
-        },
+            quote! { #[derive(#(#derives),*)] }
+        }
         None => {
-            quote!{}
+            quote! {}
         }
     };
 
@@ -205,12 +233,11 @@ fn generate_wrapped_vec(idents: &Idents, docs: &Docs) -> quote::Tokens {
 fn attr_string_val(ast: &syn::DeriveInput, attr_name: &'static str) -> Option<String> {
     if let Some(ref a) = ast.attrs.iter().find(|a| a.name() == attr_name) {
         if let syn::MetaItem::NameValue(_, syn::Lit::Str(ref val, _)) = a.value {
-            return Some(val.clone())
-        }
-        else {
-            return None
+            return Some(val.clone());
+        } else {
+            return None;
         }
     } else {
-        return None
+        return None;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,6 @@ impl Docs {
     )
 )]
 pub fn wrapped_vec(token_stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    // let args = parse_macro_input!(input as AttributeArgs);
     let input = parse_macro_input!(token_stream as DeriveInput);
     impl_wrapped_vec(&input).unwrap().into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,25 +56,25 @@ struct Docs {
 }
 
 macro_rules! doc_attr {
-    ($ast:ident, $attr:expr, $default:expr) => {
-        attr_string_val($ast, $attr).unwrap_or($default);
+    ($input:ident, $attr:expr, $default:expr) => {
+        attr_string_val($input, $attr).unwrap_or($default);
     };
 }
 
 impl Docs {
-    fn new(ast: &DeriveInput, idents: &Idents) -> Docs {
+    fn new(input: &DeriveInput, idents: &Idents) -> Docs {
         let wrapper = doc_attr!(
-            ast,
+            input,
             "CollectionDoc",
             format!("A collection of {}s", idents.item)
         );
         let new = doc_attr!(
-            ast,
+            input,
             "CollectionNewDoc",
             format!("Creates a new, empty {}", idents.collection)
         );
         let is_empty = doc_attr!(
-            ast,
+            input,
             "CollectionIsEmptyDoc",
             format!(
                 "Returns true if the {} contains no {}s",
@@ -82,7 +82,7 @@ impl Docs {
             )
         );
         let len = doc_attr!(
-            ast,
+            input,
             "CollectionLenDoc",
             format!(
                 "Returns the number of {}s in the {}",
@@ -90,7 +90,7 @@ impl Docs {
             )
         );
         let iter = doc_attr!(
-            ast,
+            input,
             "CollectionIterDoc",
             format!("Returns an iterator over the {}", idents.collection)
         );
@@ -223,8 +223,8 @@ fn generate_wrapped_vec(idents: &Idents, docs: &Docs) -> TokenStream {
     }
 }
 
-fn attr_string_val(ast: &DeriveInput, attr_name: &'static str) -> Option<String> {
-    ast.attrs.iter().find_map(|input| {
+fn attr_string_val(input: &DeriveInput, attr_name: &'static str) -> Option<String> {
+    input.attrs.iter().find_map(|input| {
         if let Ok(attribute) = input.parse_meta() {
             if let syn::Meta::NameValue(name_value) = attribute {
                 if name_value.path.is_ident(attr_name) {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,18 +2,70 @@ use wrapped_vec::WrappedVec;
 
 use std::iter::FromIterator;
 
-#[test]
-fn test_from_iter() {
-    #[derive(WrappedVec)]
-    #[CollectionName = "Fruits"]
-    pub struct Fruit {};
+#[derive(WrappedVec)]
+#[CollectionName = "Fruits"]
+pub struct Fruit {}
 
-    let fruits = Fruits::from_iter(vec![Fruit {}, Fruit {}]);
-    assert_eq!(fruits.len(), 2);
+#[test]
+fn type_exists() {
+    let _fruits: Fruits;
 }
 
 #[test]
-fn test_collection_derives() {
+fn implements_new() {
+    let _fruits = Fruits::new();
+}
+
+#[test]
+fn implements_is_empty() {
+    assert!(Fruits::new().is_empty());
+}
+
+#[test]
+fn implements_len() {
+    assert_eq!(Fruits::new().len(), 0);
+}
+
+#[test]
+fn implements_from_iterator() {
+    let _fruits = Fruits::from_iter(vec![Fruit {}, Fruit {}]);
+}
+
+#[test]
+fn implements_into_iterator() {
+    let fruits = Fruits::new();
+    for fruit in fruits.into_iter() {
+        let _f: Fruit = fruit;
+    }
+}
+
+#[test]
+fn implements_into_iterator_ref() {
+    let fruits = Fruits::new();
+    for fruit in (&fruits).into_iter() {
+        let _f: &Fruit = fruit;
+    }
+}
+
+#[test]
+fn implements_iter() {
+    let fruits = Fruits::new();
+    for _fruit in fruits.iter() {}
+}
+
+#[test]
+fn implements_extend() {
+    let mut fruits = Fruits::new();
+    fruits.extend(vec![Fruit {}, Fruit {}]);
+}
+
+#[test]
+fn implements_from_vec() {
+    let _fruits = Fruits::from(vec![Fruit {}, Fruit {}]);
+}
+
+#[test]
+fn implements_derives() {
     #[derive(Clone, Debug, WrappedVec)]
     #[CollectionName = "Fruits"]
     #[CollectionDerives = "Clone, Debug"]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,24 @@
+use wrapped_vec::WrappedVec;
+
+use std::iter::FromIterator;
+
+#[test]
+fn test_from_iter() {
+    #[derive(WrappedVec)]
+    #[CollectionName = "Fruits"]
+    pub struct Fruit {};
+
+    let fruits = Fruits::from_iter(vec![Fruit {}, Fruit {}]);
+    assert_eq!(fruits.len(), 2);
+}
+
+#[test]
+fn test_collection_derives() {
+    #[derive(Clone, Debug, WrappedVec)]
+    #[CollectionName = "Fruits"]
+    #[CollectionDerives = "Clone, Debug"]
+    pub struct Fruit {};
+
+    let _debug = format!("{:?}", Fruit {});
+    let _clone = (Fruit {}).clone();
+}


### PR DESCRIPTION
Hello (again)!

I am still hunting for dependencies bloat in polaris and I found an old version of `syn` being pulled in through `wrapped-vec`. This PR was going to simply bump dependencies, but it turns out proc macros have changed a lot since 2017 so I had to update a bit more. There's possibly terser ways to write all this but I don't know anything about proc macros myself.

Also ran rustfmt, bumped version number, wrote some basic unit tests and upgraded the crate to the 2018 Rust edition.