### PR TITLE
Bumps Rust editions +`syn` dependency & updates changelog accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+Version 0.4.0
+=============
+
+    * Updated to 2021 edition of Rust
+    * Updated `syn` dependency 
+
 Version 0.3.0
 =============
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "^1"
 quote = "^1"
-syn ="^1"
+syn = "^2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wrapped-vec"
 version = "0.3.0"
 authors = ["David Futcher <david@futcher.io>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Macro for generating wrapped Vec types and associated boilerplate"
 repository = "https://github.com/bobbo/wrapped-vec"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ struct Docs {
 
 macro_rules! doc_attr {
     ($input:ident, $attr:expr, $default:expr) => {
-        attr_string_val($input, $attr).unwrap_or($default);
+        attr_string_val($input, $attr).unwrap_or($default)
     };
 }
 
@@ -224,10 +224,10 @@ fn generate_wrapped_vec(idents: &Idents, docs: &Docs) -> TokenStream {
 
 fn attr_string_val(input: &DeriveInput, attr_name: &'static str) -> Option<String> {
     input.attrs.iter().find_map(|input| {
-        if let Ok(attribute) = input.parse_meta() {
-            if let syn::Meta::NameValue(name_value) = attribute {
-                if name_value.path.is_ident(attr_name) {
-                    if let syn::Lit::Str(s) = &name_value.lit {
+        if let syn::Meta::NameValue(name_value) = &input.meta {
+            if name_value.path.is_ident(attr_name) {
+                if let syn::Expr::Lit(expr_lit) = &name_value.value {
+                    if let syn::Lit::Str(s) = &expr_lit.lit {
                         return Some(s.value());
                     }
                 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -69,7 +69,7 @@ fn implements_derives() {
     #[derive(Clone, Debug, WrappedVec)]
     #[CollectionName = "Fruits"]
     #[CollectionDerives = "Clone, Debug"]
-    pub struct Fruit {};
+    pub struct Fruit {}
 
     let _debug = format!("{:?}", Fruit {});
     let _clone = (Fruit {}).clone();


### PR DESCRIPTION
Hello! I have this crate somewhere in my dependency chain and I noticed it's pulling a very old version of the `syn` crate.

I updated `syn` to 2.x, bumped Rust edition to 2021 and fixed a compiler warning about an unwanted semi-colon. I also updated the changelog to announce these changes.

I hope you have time to take a look at this and make a release, let me know if you would like me to make any changes!

Cheers,
Antoine